### PR TITLE
Feature/new game - place tray id in local storage

### DIFF
--- a/components/home/Home.jsx
+++ b/components/home/Home.jsx
@@ -8,7 +8,7 @@ import { useTrayContext } from '../../context/trayContext';
 const Home = () => {
   const [trays, setTrays] = useState([]);
   const [game, setGame] = useState(null);
-  const { setActiveTray } = useTrayContext();
+  const { setActiveTrayId } = useTrayContext();
   const router = useRouter();
 
   useEffect(async () => {
@@ -33,7 +33,7 @@ const Home = () => {
       })
     })
       .then((res) => res.json())
-      .then((res) => setActiveTray(res.insertedId));
+      .then((res) => setActiveTrayId(res.insertedId));
     router.push('/new-game');
   };
 

--- a/components/home/Home.jsx
+++ b/components/home/Home.jsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 const { NEXT_PUBLIC_API_URL } = process.env;
-import styles from './Home.module.css';
 import { useRouter } from 'next/router';
+import trayData from '../../data/tray.json';
+import styles from './Home.module.css';
 
 const Home = () => {
   const [trays, setTrays] = useState([]);
@@ -16,8 +17,19 @@ const Home = () => {
     await setTrays(response);
   }, []);
 
-  const onNewGameClick = () => {
+  const onNewGameClick = async () => {
     console.log('new game!!');
+    await fetch(`${NEXT_PUBLIC_API_URL}/api/trays`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/josn'
+      },
+      body: JSON.stringify({
+        ...trayData,
+        name: `Tray #${trays.length + 1}`,
+        date: new Date()
+      })
+    });
     router.push('/new-game');
   };
 

--- a/components/home/Home.jsx
+++ b/components/home/Home.jsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import trayData from '../../data/tray.json';
 import styles from './Home.module.css';
 import { useTrayContext } from '../../context/trayContext';
+import { setLocalStorage } from '../../utils/localStorage';
 
 const Home = () => {
   const [trays, setTrays] = useState([]);
@@ -33,7 +34,10 @@ const Home = () => {
       })
     })
       .then((res) => res.json())
-      .then((res) => setActiveTrayId(res.insertedId));
+      .then((res) => {
+        setLocalStorage('ACTIVE_TRAY_ID', res.insertedId);
+        setActiveTrayId(res.insertedId);
+      });
     router.push('/new-game');
   };
 

--- a/components/home/Home.jsx
+++ b/components/home/Home.jsx
@@ -1,9 +1,6 @@
 import { useEffect, useState } from 'react';
 const { NEXT_PUBLIC_API_URL } = process.env;
-import Tray from '../tray/Tray';
-import tray from '../../data/tray.json';
 import styles from './Home.module.css';
-import Link from 'next/link';
 import { useRouter } from 'next/router';
 
 const Home = () => {
@@ -51,7 +48,6 @@ const Home = () => {
             ))}
         </select>
       </section>
-      <Tray active={false} name={tray.name} rows={tray.rows} />
     </div>
   );
 };

--- a/components/home/Home.jsx
+++ b/components/home/Home.jsx
@@ -3,10 +3,13 @@ const { NEXT_PUBLIC_API_URL } = process.env;
 import Tray from '../tray/Tray';
 import tray from '../../data/tray.json';
 import styles from './Home.module.css';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
 
 const Home = () => {
   const [trays, setTrays] = useState([]);
   const [game, setGame] = useState(null);
+  const router = useRouter();
 
   useEffect(async () => {
     const response = await fetch(`${NEXT_PUBLIC_API_URL}/api/trays`).then(
@@ -18,7 +21,7 @@ const Home = () => {
 
   const onNewGameClick = () => {
     console.log('new game!!');
-    alert("This isn't working yet.");
+    router.push('/new-game');
   };
 
   const onSelectGame = async (e) => {

--- a/components/home/Home.jsx
+++ b/components/home/Home.jsx
@@ -29,7 +29,9 @@ const Home = () => {
         name: `Tray #${trays.length + 1}`,
         date: new Date()
       })
-    });
+    })
+      .then((res) => res.json())
+      .then((res) => console.log(res));
     router.push('/new-game');
   };
 

--- a/components/home/Home.jsx
+++ b/components/home/Home.jsx
@@ -3,10 +3,12 @@ const { NEXT_PUBLIC_API_URL } = process.env;
 import { useRouter } from 'next/router';
 import trayData from '../../data/tray.json';
 import styles from './Home.module.css';
+import { useTrayContext } from '../../context/trayContext';
 
 const Home = () => {
   const [trays, setTrays] = useState([]);
   const [game, setGame] = useState(null);
+  const { setActiveTray } = useTrayContext();
   const router = useRouter();
 
   useEffect(async () => {
@@ -31,7 +33,7 @@ const Home = () => {
       })
     })
       .then((res) => res.json())
-      .then((res) => console.log(res));
+      .then((res) => setActiveTray(res.insertedId));
     router.push('/new-game');
   };
 

--- a/components/home/Home.module.css
+++ b/components/home/Home.module.css
@@ -1,7 +1,10 @@
+.Home {
+  padding-top: 4rem;
+}
+
 .Home section {
   width: fit-content;
   margin-inline: auto;
-  padding-block: 1rem;
   display: flex;
   flex-direction: row;
   gap: 2rem;

--- a/components/layout/Layout.module.css
+++ b/components/layout/Layout.module.css
@@ -1,4 +1,5 @@
 .Layout {
   background-color: #1c1f2d;
   min-width: fit-content;
+  min-height: 100vh;
 }

--- a/components/select/Select.jsx
+++ b/components/select/Select.jsx
@@ -1,8 +1,12 @@
+import { useTrayContext } from '../../context/trayContext';
 import trayData from '../../data/tray.json';
 import Tray from '../tray/Tray';
 import styles from './Select.module.css';
 
 const Select = () => {
+  const { activeTray } = useTrayContext();
+  console.log(activeTray);
+
   return (
     <div className={styles.Select}>
       <h3>Click on tiles to add them to your tray.</h3>

--- a/components/select/Select.jsx
+++ b/components/select/Select.jsx
@@ -1,16 +1,25 @@
+import { useEffect, useState } from 'react';
 import { useTrayContext } from '../../context/trayContext';
 import trayData from '../../data/tray.json';
+const { NEXT_PUBLIC_API_URL } = process.env;
 import Tray from '../tray/Tray';
 import styles from './Select.module.css';
 
 const Select = () => {
+  const [game, setGame] = useState(null);
   const { activeTray } = useTrayContext();
   console.log(activeTray);
+
+  useEffect(async () => {
+    await fetch(`${NEXT_PUBLIC_API_URL}/api/trays/?id=${activeTray}`)
+      .then((res) => res.json())
+      .then((res) => setGame(res));
+  }, []);
 
   return (
     <div className={styles.Select}>
       <h3>Click on tiles to add them to your tray.</h3>
-      <Tray active={false} name={trayData.name} rows={trayData.rows} />
+      {game && <Tray active={false} name={game.name} rows={game.rows} />}
     </div>
   );
 };

--- a/components/select/Select.jsx
+++ b/components/select/Select.jsx
@@ -1,0 +1,14 @@
+import trayData from '../../data/tray.json';
+import Tray from '../tray/Tray';
+import styles from './Select.module.css';
+
+const Select = () => {
+  return (
+    <div className={styles.Select}>
+      <h3>Click on tiles to add them to your tray.</h3>
+      <Tray active={false} name={trayData.name} rows={trayData.rows} />
+    </div>
+  );
+};
+
+export default Select;

--- a/components/select/Select.jsx
+++ b/components/select/Select.jsx
@@ -14,14 +14,12 @@ const Select = () => {
       ? activeTrayId
       : getLocalStorage('ACTIVE_TRAY_ID');
 
-    setActiveTrayId(id);
+    if (!activeTrayId.length) setActiveTrayId(id);
 
     await fetch(`${NEXT_PUBLIC_API_URL}/api/trays/?id=${id}`)
       .then((res) => res.json())
       .then((res) => setTray(res));
   }, []);
-
-  console.log({ activeTrayId });
 
   return (
     <div className={styles.Select}>

--- a/components/select/Select.jsx
+++ b/components/select/Select.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useTrayContext } from '../../context/trayContext';
+import { getLocalStorage } from '../../utils/localStorage';
 const { NEXT_PUBLIC_API_URL } = process.env;
 import Tray from '../tray/Tray';
 import styles from './Select.module.css';
@@ -10,9 +11,17 @@ const Select = () => {
   console.log(activeTrayId);
 
   useEffect(async () => {
-    await fetch(`${NEXT_PUBLIC_API_URL}/api/trays/?id=${activeTrayId}`)
-      .then((res) => res.json())
-      .then((res) => setTray(res));
+    if (activeTrayId.length) {
+      await fetch(`${NEXT_PUBLIC_API_URL}/api/trays/?id=${activeTrayId}`)
+        .then((res) => res.json())
+        .then((res) => setTray(res));
+    } else {
+      const id = getLocalStorage('ACTIVE_TRAY_ID');
+
+      await fetch(`${NEXT_PUBLIC_API_URL}/api/trays/?id=${id}`)
+        .then((res) => res.json())
+        .then((res) => setTray(res));
+    }
   }, []);
 
   return (

--- a/components/select/Select.jsx
+++ b/components/select/Select.jsx
@@ -8,20 +8,15 @@ import styles from './Select.module.css';
 const Select = () => {
   const [tray, setTray] = useState(null);
   const { activeTrayId } = useTrayContext();
-  console.log(activeTrayId);
 
   useEffect(async () => {
-    if (activeTrayId.length) {
-      await fetch(`${NEXT_PUBLIC_API_URL}/api/trays/?id=${activeTrayId}`)
-        .then((res) => res.json())
-        .then((res) => setTray(res));
-    } else {
-      const id = getLocalStorage('ACTIVE_TRAY_ID');
+    const id = activeTrayId.length
+      ? activeTrayId
+      : getLocalStorage('ACTIVE_TRAY_ID');
 
-      await fetch(`${NEXT_PUBLIC_API_URL}/api/trays/?id=${id}`)
-        .then((res) => res.json())
-        .then((res) => setTray(res));
-    }
+    await fetch(`${NEXT_PUBLIC_API_URL}/api/trays/?id=${id}`)
+      .then((res) => res.json())
+      .then((res) => setTray(res));
   }, []);
 
   return (

--- a/components/select/Select.jsx
+++ b/components/select/Select.jsx
@@ -7,17 +7,21 @@ import styles from './Select.module.css';
 
 const Select = () => {
   const [tray, setTray] = useState(null);
-  const { activeTrayId } = useTrayContext();
+  const { activeTrayId, setActiveTrayId } = useTrayContext();
 
   useEffect(async () => {
     const id = activeTrayId.length
       ? activeTrayId
       : getLocalStorage('ACTIVE_TRAY_ID');
 
+    setActiveTrayId(id);
+
     await fetch(`${NEXT_PUBLIC_API_URL}/api/trays/?id=${id}`)
       .then((res) => res.json())
       .then((res) => setTray(res));
   }, []);
+
+  console.log({ activeTrayId });
 
   return (
     <div className={styles.Select}>

--- a/components/select/Select.jsx
+++ b/components/select/Select.jsx
@@ -18,7 +18,8 @@ const Select = () => {
 
   return (
     <div className={styles.Select}>
-      <h3>Click on tiles to add them to your tray.</h3>
+      <h3>{game.name}</h3>
+      <p>Click on tiles to add them to your tray.</p>
       {game && <Tray active={false} name={game.name} rows={game.rows} />}
     </div>
   );

--- a/components/select/Select.jsx
+++ b/components/select/Select.jsx
@@ -1,26 +1,25 @@
 import { useEffect, useState } from 'react';
 import { useTrayContext } from '../../context/trayContext';
-import trayData from '../../data/tray.json';
 const { NEXT_PUBLIC_API_URL } = process.env;
 import Tray from '../tray/Tray';
 import styles from './Select.module.css';
 
 const Select = () => {
-  const [game, setGame] = useState(null);
-  const { activeTray } = useTrayContext();
-  console.log(activeTray);
+  const [tray, setTray] = useState(null);
+  const { activeTrayId } = useTrayContext();
+  console.log(activeTrayId);
 
   useEffect(async () => {
-    await fetch(`${NEXT_PUBLIC_API_URL}/api/trays/?id=${activeTray}`)
+    await fetch(`${NEXT_PUBLIC_API_URL}/api/trays/?id=${activeTrayId}`)
       .then((res) => res.json())
-      .then((res) => setGame(res));
+      .then((res) => setTray(res));
   }, []);
 
   return (
     <div className={styles.Select}>
-      <h3>{game.name}</h3>
+      <h3>{tray && tray.name}</h3>
       <p>Click on tiles to add them to your tray.</p>
-      {game && <Tray active={false} name={game.name} rows={game.rows} />}
+      {tray && <Tray active={false} name={tray.name} rows={tray.rows} />}
     </div>
   );
 };

--- a/components/select/Select.module.css
+++ b/components/select/Select.module.css
@@ -4,7 +4,9 @@
   color: hsl(0, 0%, 90%);
 }
 
-.Select h3 {
+.Select h3,
+.Select h3 + p {
   width: fit-content;
   margin-inline: auto;
+  margin-bottom: 0.5rem;
 }

--- a/components/select/Select.module.css
+++ b/components/select/Select.module.css
@@ -1,0 +1,10 @@
+.Select {
+  padding: 1rem;
+
+  color: hsl(0, 0%, 90%);
+}
+
+.Select h3 {
+  width: fit-content;
+  margin-inline: auto;
+}

--- a/context/trayContext.js
+++ b/context/trayContext.js
@@ -3,22 +3,22 @@ import { createContext, useContext, useState } from 'react';
 const TrayContext = createContext(null);
 
 export const TrayProvider = ({ children }) => {
-  const [activeTray, setActiveTray] = useState([]);
+  const [activeTrayId, setActiveTrayId] = useState([]);
 
-  // const currentActiveTray = (id) => {
-  //   setActiveTray(id);
-  //   return activeTray;
+  // const currentActiveTrayId = (id) => {
+  //   setActiveTrayId(id);
+  //   return activeTrayId;
   // };
 
   return (
-    <TrayContext.Provider value={{ activeTray, setActiveTray }}>
+    <TrayContext.Provider value={{ activeTrayId, setActiveTrayId }}>
       {children}
     </TrayContext.Provider>
   );
 };
 
 export const useTrayContext = () => {
-  const { activeTray, setActiveTray } = useContext(TrayContext);
+  const { activeTrayId, setActiveTrayId } = useContext(TrayContext);
 
-  return { activeTray, setActiveTray };
+  return { activeTrayId, setActiveTrayId };
 };

--- a/context/trayContext.js
+++ b/context/trayContext.js
@@ -1,0 +1,24 @@
+import { createContext, useContext, useState } from 'react';
+
+const TrayContext = createContext(null);
+
+export const TrayProvider = ({ children }) => {
+  const [activeTray, setActiveTray] = useState([]);
+
+  // const currentActiveTray = (id) => {
+  //   setActiveTray(id);
+  //   return activeTray;
+  // };
+
+  return (
+    <TrayContext.Provider value={{ activeTray, setActiveTray }}>
+      {children}
+    </TrayContext.Provider>
+  );
+};
+
+export const useTrayContext = () => {
+  const { activeTray, setActiveTray } = useContext(TrayContext);
+
+  return { activeTray, setActiveTray };
+};

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,10 +1,13 @@
 import Layout from '../components/layout/Layout';
+import { TrayProvider } from '../context/trayContext';
 import '../styles/globals.css';
 
 export default function MyApp({ Component, pageProps }) {
   return (
-    <Layout>
-      <Component {...pageProps} />
-    </Layout>
+    <TrayProvider>
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    </TrayProvider>
   );
 }

--- a/pages/api/trays.js
+++ b/pages/api/trays.js
@@ -24,7 +24,9 @@ export default async function handler(req, res) {
       }
       break;
     case 'POST':
-      const response = await db.collection('trays').insertOne(req.body);
+      const response = await db
+        .collection('trays')
+        .insertOne(JSON.parse(req.body));
       res.json(response);
       break;
     default:

--- a/pages/new-game.js
+++ b/pages/new-game.js
@@ -1,10 +1,11 @@
 import Home from '../components/home/Home';
+import Select from '../components/select/Select';
 import clientPromise from '../lib/mongodb';
 
 export default function NewGame({ isConnected }) {
   return (
     <div>
-      <h2>New Game</h2>
+      <Select />
     </div>
   );
 }

--- a/pages/new-game.js
+++ b/pages/new-game.js
@@ -1,0 +1,37 @@
+import Home from '../components/home/Home';
+import clientPromise from '../lib/mongodb';
+
+export default function NewGame({ isConnected }) {
+  return (
+    <div>
+      <h2>New Game</h2>
+    </div>
+  );
+}
+
+export async function getServerSideProps(context) {
+  try {
+    await clientPromise;
+    // `await clientPromise` will use the default database passed in the MONGODB_URI
+    // However you can use another database (e.g. myDatabase) by replacing the `await clientPromise` with the following code:
+    //
+    // const client = await clientPromise;
+    // const db = client.db('eclipseDB');
+    //
+    // Then you can execute queries against your database like so:
+    // db.find({}) or any of the MongoDB Node Driver commands
+
+    // const raw = await db.collection('trays').find({}).toArray();
+
+    // const data = await JSON.parse(JSON.stringify(raw));
+
+    return {
+      props: { isConnected: true }
+    };
+  } catch (e) {
+    console.error(e);
+    return {
+      props: { isConnected: false }
+    };
+  }
+}

--- a/utils/localStorage.js
+++ b/utils/localStorage.js
@@ -1,0 +1,7 @@
+export const setLocalStorage = (key, id) => {
+  localStorage.setItem(key, id);
+};
+
+export const getLocalStorage = (key) => {
+  return localStorage.getItem(key);
+};


### PR DESCRIPTION
The New Game page received the tray id from context to GET the correct tray from the database. Placing the tray id in local storage will allow the New Game page to still have access to the tray id even when the New Game page is reloaded (and the context state is lost). This will also re-save the tray id in context state.